### PR TITLE
chore(dev): make Jitpack use JDK 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+# Jitpack configuration
+jdk:
+  # Build on oldest LTS version supporting modules
+  - openjdk11


### PR DESCRIPTION
Use oldest LTS JDK that supports modularity.