### PR TITLE
chore: Update versions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 1.3.1   | :white_check_mark: |
+| 2.0.0   | :white_check_mark: |
+| 1.3.1   | :x:                |
 | 1.3.0   | :x:                |
 | < 1.3   | :x:                |
 


### PR DESCRIPTION
Because I can't publish updates to Maven Central, mark 1.3.x as unsupported.