### PR TITLE
Increase dependabot intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,9 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: weekly
-    time: "10:00"
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly


### PR DESCRIPTION
I need to slow the pace of non-security changes for my own sanity.