### PR TITLE
feat: add Java 25 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
+        - java: 8
         - java: 11
         - java: 17
         - java: 21

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         include:
-        - java: 8
         - java: 11
         - java: 17
         - java: 21
+        - java: 25
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1


### PR DESCRIPTION
Add CI checks for Java 25. This is a needed step to allow Java 25 CI to be required before addressing #554.