### PR TITLE
chore: remove CI builds for Java 8 and 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         include:
-        - java: 8
-        - java: 11
         - java: 17
         - java: 21
         - java: 25


### PR DESCRIPTION
Fix #563