### PR TITLE
chore: address CodeQL warning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,6 +58,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        build-mode: 'none'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Set an explicit build mode to silence the warning:

> Cannot build an overlay-base database because build-mode is set to "undefined" instead of "none". Falling back to creating a normal full database instead.